### PR TITLE
Update routing to expose bazinga_jstranslation_js

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -4,6 +4,7 @@ bazinga_jstranslation_js:
     methods:  [ GET ]
     options:
         i18n: false
+        expose: true
     requirements:
         _format: js|json
         domain: "[\w]+"


### PR DESCRIPTION
This allows the bundle to be used in combination with the FOSJsRoutingBundle, and load a specific translation file via javascript / jQuery, "on demand".

Usage example:

``` javascript
// with jquery
$.getScript(Routing.generate('bazinga_jstranslation_js', {'domain': 'my-custom-domain'}), function(){
    alert(Translator.trans('say.hello', {}, 'my-custom-domain'));
});
```

I'm not sure if this has any side effect I'm not aware of, but this works pretty well.
